### PR TITLE
add sample for acm certificate

### DIFF
--- a/acm-route53/README.md
+++ b/acm-route53/README.md
@@ -1,0 +1,41 @@
+# Generating an ACM certificate via Terraform
+
+This example shows how to generate an ACM certificate for a domain via Terraform.
+
+### Requirements
+
+- LocalStack Community
+- Terraform CLI
+- `tflocal` wrapper script
+- `awslocal` wrapper script
+
+## Run
+
+To run this example you need to execute:
+
+```bash
+tflocal init
+tflocal plan
+tflocal apply --auto-approve
+```
+
+## Testing
+
+Run the following command to test the example:
+
+```bash
+awslocal acm list-certificates
+```
+
+You will see the following output:
+
+```json
+{
+    "CertificateSummaryList": [
+        {
+            "CertificateArn": "arn:aws:acm:<REGION>:000000000000:certificate/<CERTIFICATE-ID>",
+            "DomainName": "helloworld.info"
+        }
+    ]
+}
+```

--- a/acm-route53/main.tf
+++ b/acm-route53/main.tf
@@ -1,0 +1,30 @@
+variable "root_domain_name" {
+  type    = string
+  default = "helloworld.info"
+}
+
+resource "aws_route53_zone" "hello_world_zone" {
+  name = var.root_domain_name
+}
+
+resource "aws_acm_certificate" "hello_certificate" {
+  domain_name       = var.root_domain_name
+  validation_method = "DNS"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "hello_cert_dns" {
+  allow_overwrite = true
+  name            = tolist(aws_acm_certificate.hello_certificate.domain_validation_options)[0].resource_record_name
+  records         = [tolist(aws_acm_certificate.hello_certificate.domain_validation_options)[0].resource_record_value]
+  type            = tolist(aws_acm_certificate.hello_certificate.domain_validation_options)[0].resource_record_type
+  zone_id         = aws_route53_zone.hello_world_zone.zone_id
+  ttl             = 60
+}
+
+resource "aws_acm_certificate_validation" "hello_cert_validate" {
+  certificate_arn         = aws_acm_certificate.hello_certificate.arn
+  validation_record_fqdns = [aws_route53_record.hello_cert_dns.fqdn]
+}

--- a/acm-route53/provider.tf
+++ b/acm-route53/provider.tf
@@ -1,0 +1,35 @@
+provider "aws" {
+  access_key                  = "test"
+  secret_key                  = "test"
+  region                      = "us-east-1"
+  s3_use_path_style           = false
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    apigateway     = "http://localhost:4566"
+    apigatewayv2   = "http://localhost:4566"
+    cloudformation = "http://localhost:4566"
+    cloudwatch     = "http://localhost:4566"
+    dynamodb       = "http://localhost:4566"
+    ec2            = "http://localhost:4566"
+    es             = "http://localhost:4566"
+    elasticache    = "http://localhost:4566"
+    firehose       = "http://localhost:4566"
+    iam            = "http://localhost:4566"
+    kinesis        = "http://localhost:4566"
+    lambda         = "http://localhost:4566"
+    rds            = "http://localhost:4566"
+    redshift       = "http://localhost:4566"
+    route53        = "http://localhost:4566"
+    s3             = "http://s3.localhost.localstack.cloud:4566"
+    secretsmanager = "http://localhost:4566"
+    ses            = "http://localhost:4566"
+    sns            = "http://localhost:4566"
+    sqs            = "http://localhost:4566"
+    ssm            = "http://localhost:4566"
+    stepfunctions  = "http://localhost:4566"
+    sts            = "http://localhost:4566"
+  }
+}


### PR DESCRIPTION
This PR:

- Adds a sample for generating an ACM certificate for a domain via Terraform.
- Adds specific documentation for the instructions to run the sample.