### PR TITLE
Major: rename default container name to localstack-main

### DIFF
--- a/lambda-kinesis-firehose-es/docker-compose.yml
+++ b/lambda-kinesis-firehose-es/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     ports:
       - "4566:4566"            # LocalStack Gateway


### PR DESCRIPTION
# Motivation

Hyphens are not allowed in URLs. When addressing the LocalStack container over a docker network, the container name resolves to the IP address of the container. This is a problem in particular for boto3 which refuses to connect.

# Changes

This PR updates usages of `localstack_main` to `localstack-main`.
