### PR TITLE
align s3-static-website sample with docs tutorial and rename deprecated path-style flag

### DIFF
--- a/s3-static-website/outputs.tf
+++ b/s3-static-website/outputs.tf
@@ -12,9 +12,10 @@ output "name" {
 
 output "domain" {
   description = "Domain name of the bucket"
-  value       = aws_s3_bucket_website_configuration.s3_bucket.website_domain
+  value       = "s3-website.localhost.localstack.cloud:4566"
 }
 
 output "website_endpoint" {
-  value = aws_s3_bucket_website_configuration.s3_bucket.website_endpoint
+  description = "Website endpoint URL"
+  value       = "http://${aws_s3_bucket.s3_bucket.id}.s3-website.localhost.localstack.cloud:4566"
 }

--- a/s3-static-website/outputs.tf
+++ b/s3-static-website/outputs.tf
@@ -1,20 +1,20 @@
 # Output variable definitions
 
-output "bucket_arn" {
+output "arn" {
   description = "ARN of the bucket"
   value       = aws_s3_bucket.s3_bucket.arn
 }
 
-output "bucket_name" {
+output "name" {
   description = "Name (id) of the bucket"
   value       = aws_s3_bucket.s3_bucket.id
 }
 
 output "domain" {
   description = "Domain name of the bucket"
-  value       = "s3-website.localhost.localstack.cloud:4566"
+  value       = aws_s3_bucket_website_configuration.s3_bucket.website_domain
 }
 
 output "website_endpoint" {
-  value = "https://${aws_s3_bucket.s3_bucket.id}.s3-website.localhost.localstack.cloud:4566"
+  value = aws_s3_bucket_website_configuration.s3_bucket.website_endpoint
 }

--- a/s3-static-website/provider.tf
+++ b/s3-static-website/provider.tf
@@ -2,34 +2,15 @@ provider "aws" {
   access_key                  = "test"
   secret_key                  = "test"
   region                      = "us-east-1"
-  s3_force_path_style         = false
+
+  # only required for non virtual hosted-style endpoint use case.
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs#s3_force_path_style
+  s3_use_path_style           = true
   skip_credentials_validation = true
   skip_metadata_api_check     = true
-  skip_requesting_account_id  = true
 
   endpoints {
-    apigateway     = "http://localhost:4566"
-    apigatewayv2   = "http://localhost:4566"
-    cloudformation = "http://localhost:4566"
-    cloudwatch     = "http://localhost:4566"
-    dynamodb       = "http://localhost:4566"
-    ec2            = "http://localhost:4566"
-    es             = "http://localhost:4566"
-    elasticache    = "http://localhost:4566"
-    firehose       = "http://localhost:4566"
-    iam            = "http://localhost:4566"
-    kinesis        = "http://localhost:4566"
-    lambda         = "http://localhost:4566"
-    rds            = "http://localhost:4566"
-    redshift       = "http://localhost:4566"
-    route53        = "http://localhost:4566"
     s3             = "http://s3.localhost.localstack.cloud:4566"
-    secretsmanager = "http://localhost:4566"
-    ses            = "http://localhost:4566"
-    sns            = "http://localhost:4566"
-    sqs            = "http://localhost:4566"
-    ssm            = "http://localhost:4566"
-    stepfunctions  = "http://localhost:4566"
-    sts            = "http://localhost:4566"
+    s3control      = "http://localhost.localstack.cloud:4566"
   }
 }

--- a/s3-static-website/provider.tf
+++ b/s3-static-website/provider.tf
@@ -4,13 +4,13 @@ provider "aws" {
   region                      = "us-east-1"
 
   # only required for non virtual hosted-style endpoint use case.
-  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs#s3_force_path_style
-  s3_use_path_style           = true
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs#s3_use_path_style
+  s3_use_path_style           = false
   skip_credentials_validation = true
   skip_metadata_api_check     = true
 
   endpoints {
-    s3             = "http://s3.localhost.localstack.cloud:4566"
-    s3control      = "http://localhost.localstack.cloud:4566"
+    s3        = "http://s3.localhost.localstack.cloud:4566"
+    s3control = "http://localhost.localstack.cloud:4566"
   }
 }


### PR DESCRIPTION
Related PR: https://github.com/localstack/localstack-docs/pull/495

Fixes [DOC-113](https://linear.app/localstack/issue/DOC-113/doc-bug-fix-tutorial-mentioning-newer-s3-use-path-style-in-providertf)

## Summary

- `provider.tf`: deprecated `s3_force_path_style` → `s3_use_path_style = false`. Trimmed 22 unused service endpoints (this sample only uses S3) and removed `skip_requesting_account_id`. 
- Added `s3control` endpoint since newer AWS provider versions read bucket tags via the S3 Control API, which fails without it.                                              
- `outputs.tf`: `bucket_arn` → `arn`, `bucket_name` → `name` (matches docs tutorial). Kept the LocalStack-formatted hardcoded URLs so users see an openable address; switched the scheme from `https` → `http` to match the working LocalStack S3-website endpoint, and added `description` fields.                                                                                                    
                                                                                                                                     
After this PR, `provider.tf` and `outputs.tf` are byte-equivalent between docs and sample.
